### PR TITLE
Add optional displayname argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ python3 femtosip.py \
     --user SIP_USER \             # SIP username
     --password SIP_PASSWORD \     # SIP password
     --call '**9' \                # Which phone number to call
-    --delay 15.0                  # How long to wait til hanging up
+    --delay 15.0 \                # How long to wait til hanging up
+    --displayname MyCustomName    # Set the display name, if different from SIP login
 ```
 
 If everything works, you should get an output which looks like this:
@@ -48,7 +49,7 @@ If everything works, you should get an output which looks like this:
 Alternatively, you can call `femtosip` from another Python script via
 ```python
 import femtosip
-sip = femtosip.SIP(user, password, gateway, port)
+sip = femtosip.SIP(user, password, gateway, port, display_name)
 sip.call(call, delay)
 ```
 The example script `rpi_sip_doorbell.py` demonstrates basic usage of `femtosip`
@@ -71,6 +72,7 @@ This code was hacked together in a few hours and tested with the following SIP
 servers
 
 * AVM FRITZ!Box Fon WLAN 7390
+* AVM FRITZ!Box WLAN 7490
 * linphone 3.6.1 (libexosip2/3.6)
 
 It is not guaranteed to work with any other server. Especially, it uses a TCP

--- a/femtosip.py
+++ b/femtosip.py
@@ -253,13 +253,14 @@ class SIP:
 
     ALLOW = 'INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY, MESSAGE, SUBSCRIBE, INFO'
 
-    def __init__(self, user, password, gateway, port):
+    def __init__(self, user, password, gateway, port, display_name=''):
         # Copy the parameters
         self.user = user
         self.password = password
         self.local_ip, self.local_port = None, None # To be read dynamically
         self.gateway = gateway
         self.port = port
+        self.display_name = display_name
 
         # Initilise the session parameters
         self.seq = 0
@@ -312,7 +313,7 @@ class SIP:
             'SIP/2.0/TCP ' + self.local_ip + ':' + str(self.port) +
             ';rport;branch=' + branch)
         fields['From'] = (
-            '<sip:' + self.user + '@' + remote_host + '>;tag=' + tag)
+            f'"{self.display_name}" <sip:{self.user}@{remote_host}>;tag={tag}')
         fields['To'] = (
             '<sip:' + remote_id + '@' + remote_host + '>')
         fields['Call-ID'] = str(call_id)
@@ -348,7 +349,7 @@ class SIP:
             'SIP/2.0/TCP ' + self.local_ip + ':' + str(self.port) +
             ';rport;branch=' + branch)
         fields['From'] = (
-            '<sip:' + self.user + '@' + remote_host + '>;tag=' + tag)
+            f'"{self.display_name}" <sip:{self.user}@{remote_host}>;tag={tag}')
         fields['To'] = (
             '<sip:' + remote_id + '@' + remote_host + '>')
         fields['Call-ID'] = str(call_id)
@@ -367,7 +368,7 @@ class SIP:
             'SIP/2.0/TCP ' + self.local_ip + ':' + str(self.port) +
             ';rport;branch=' + branch)
         fields['From'] = (
-            '<sip:' + self.user + '@' + remote_host + '>;tag=' + tag)
+            f'"{self.display_name}" <sip:{self.user}@{remote_host}>;tag={tag}')
         fields['To'] = (
             '<sip:' + remote_id + '@' + remote_host + '>;tag=' + remote_tag)
         fields['Call-ID'] = str(call_id)
@@ -537,6 +538,8 @@ if __name__ == '__main__':
     parser.add_argument('--password', default='',
         help='Password used in conjunction with the user for authentication ' +
              'at the SIP server. (default '')')
+    parser.add_argument('--displayname', default='', help='Alter the displayed ' +
+             'caller name. (defaults to SIP configuration)')
     parser.add_argument('--call', required=True,
         help='Phone number of the endpoint that will be called.')
     parser.add_argument('--delay', default=15.0, type=float,
@@ -545,6 +548,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
-    sip = SIP(args.user, args.password, args.gateway, args.port)
+    sip = SIP(args.user, args.password, args.gateway, args.port, args.displayname)
     sip.call(args.call, args.delay)
 

--- a/femtosip.py
+++ b/femtosip.py
@@ -253,7 +253,7 @@ class SIP:
 
     ALLOW = 'INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY, MESSAGE, SUBSCRIBE, INFO'
 
-    def __init__(self, user, password, gateway, port, display_name=''):
+    def __init__(self, user, password, gateway, port, display_name=None):
         # Copy the parameters
         self.user = user
         self.password = password
@@ -301,6 +301,16 @@ class SIP:
     def make_branch(self):
         return 'z9hG4bK' + self.make_random_digits(10)
 
+    def make_from_field(self, remote_host:str, tag: str):
+
+        from_field = f'<sip:{self.user}@{remote_host}>;tag={tag}'
+
+        if self.display_name:
+            from_field = f'"{self.display_name}" ' + from_field
+
+        return from_field
+
+
     def make_invite_sip_packet(self,
             remote_id, remote_host,
             branch, tag, call_id, seq, realm=None, nonce=None):
@@ -312,8 +322,7 @@ class SIP:
         fields['Via'] = (
             'SIP/2.0/TCP ' + self.local_ip + ':' + str(self.port) +
             ';rport;branch=' + branch)
-        fields['From'] = (
-            f'"{self.display_name}" <sip:{self.user}@{remote_host}>;tag={tag}')
+        fields['From'] = self.make_from_field(remote_host, tag)
         fields['To'] = (
             '<sip:' + remote_id + '@' + remote_host + '>')
         fields['Call-ID'] = str(call_id)
@@ -348,8 +357,7 @@ class SIP:
         fields['Via'] = (
             'SIP/2.0/TCP ' + self.local_ip + ':' + str(self.port) +
             ';rport;branch=' + branch)
-        fields['From'] = (
-            f'"{self.display_name}" <sip:{self.user}@{remote_host}>;tag={tag}')
+        fields['From'] = self.make_from_field(remote_host, tag)
         fields['To'] = (
             '<sip:' + remote_id + '@' + remote_host + '>')
         fields['Call-ID'] = str(call_id)
@@ -367,8 +375,7 @@ class SIP:
         fields['Via'] = (
             'SIP/2.0/TCP ' + self.local_ip + ':' + str(self.port) +
             ';rport;branch=' + branch)
-        fields['From'] = (
-            f'"{self.display_name}" <sip:{self.user}@{remote_host}>;tag={tag}')
+        fields['From'] = self.make_from_field(remote_host, tag)
         fields['To'] = (
             '<sip:' + remote_id + '@' + remote_host + '>;tag=' + remote_tag)
         fields['Call-ID'] = str(call_id)
@@ -538,7 +545,7 @@ if __name__ == '__main__':
     parser.add_argument('--password', default='',
         help='Password used in conjunction with the user for authentication ' +
              'at the SIP server. (default '')')
-    parser.add_argument('--displayname', default='', help='Alter the displayed ' +
+    parser.add_argument('--displayname', default=None, help='Alter the displayed ' +
              'caller name. (defaults to SIP configuration)')
     parser.add_argument('--call', required=True,
         help='Phone number of the endpoint that will be called.')

--- a/rpi_sip_doorbell.py
+++ b/rpi_sip_doorbell.py
@@ -31,6 +31,8 @@ parser.add_argument('--user', required=True,
 parser.add_argument('--password', default='',
     help='Password used in conjunction with the user for authentication ' +
          'at the SIP server. (default '')')
+parser.add_argument('--displayname', default='', help='Alter the displayed ' +
+             'caller name. (defaults to SIP configuration)')
 parser.add_argument('--call', required=True,
     help='Phone number of the endpoint that will be called.')
 parser.add_argument('--delay', default=15.0, type=float,
@@ -71,7 +73,7 @@ GPIO.add_event_detect(args.gpio, GPIO.FALLING,
 
 # Setup the SIP client
 import femtosip
-sip = femtosip.SIP(args.user, args.password, args.gateway, args.port)
+sip = femtosip.SIP(args.user, args.password, args.gateway, args.port, args.displayname)
 
 # Loop eternally and trigger a call whenever an event is detected
 import time

--- a/rpi_sip_doorbell.py
+++ b/rpi_sip_doorbell.py
@@ -31,7 +31,7 @@ parser.add_argument('--user', required=True,
 parser.add_argument('--password', default='',
     help='Password used in conjunction with the user for authentication ' +
          'at the SIP server. (default '')')
-parser.add_argument('--displayname', default='', help='Alter the displayed ' +
+parser.add_argument('--displayname', default=None, help='Alter the displayed ' +
              'caller name. (defaults to SIP configuration)')
 parser.add_argument('--call', required=True,
     help='Phone number of the endpoint that will be called.')


### PR DESCRIPTION
This PR adds the possibility to set the display name of the call to a custom string.

#### Motivation
When using this lib for home-automation the reason for triggering the call cannot be distinguished, if the same SIP-User is used for multiple use-cases.
Adding the displayname will gives the option to show a short ascii string at the receiving end of the call.


#### Implementation

The previous state will not send a specific display name and the called phones will therefore always displaye the default name set by the SIP server/login.

This can be changed by prepending a string to the "from" field.

Previous "from"-string:
`From: <sip:Login@gateway>;tag=123456 `


"from"-string with custom display name:
`From: "MyName" <sip:Login@gateway>;tag=123456 `

"from"-string with default display name after PR:
`From: "" <sip:Login@gateway>;tag=123456 `


I added a new optional parser argument `--displayname` and a new consturctor parameter `display_name=''`, defaulting to the previous behaviour. This achieves full backwards compatibility.

##### Validation
The empty string "" will result in the display of the default name, as before this PR.
This is tested with FritzBox 7490 (and some Phillips dect phones), PhonerLite  and Wireshark.
The test cases are still running successfull (the tested code was not changed anyway)