### PR TITLE
Add PJSIP compatibility, remove redundant semicolons

### DIFF
--- a/femtosip.py
+++ b/femtosip.py
@@ -432,7 +432,7 @@ class SIP:
                     return
                 auth = str(res.fields['WWW-Authenticate'], 'ascii')
                 match = re.match(
-                    r'^[Dd]igest\s+realm="([^"]*)"\s*,\s*nonce="([^"]*)"$',
+                    r'^[Dd]igest\s+realm="([^"]*)"\s*,\s*nonce="([^"]*)".*$',
                     auth)
                 if not res:
                     error('Could not parse "WWW-Authenticate" header, authentication methods other than digest are not supported.')

--- a/femtosip.py
+++ b/femtosip.py
@@ -264,8 +264,8 @@ class SIP:
 
         # Initilise the session parameters
         self.seq = 0
-        self.session_id = self.make_random_digits(4);
-        self.session_version = self.make_random_digits(4);
+        self.session_id = self.make_random_digits(4)
+        self.session_version = self.make_random_digits(4)
 
     @staticmethod
     def make_sip_packet(method, uri, fields, data=b''):
@@ -293,7 +293,7 @@ class SIP:
 
     @staticmethod
     def make_random_digits(len=10):
-        res = '';
+        res = ''
         for i in range(len):
             res += str(random.randint(1 if i == 0 else 0, 9))
         return res
@@ -314,7 +314,7 @@ class SIP:
             remote_id, remote_host,
             branch, tag, call_id, seq, realm=None, nonce=None):
         # Assemble the request uri
-        uri = 'sip:' + remote_id + '@' + remote_host;
+        uri = 'sip:' + remote_id + '@' + remote_host
 
         # Assemble the header fields
         fields = collections.OrderedDict()
@@ -349,7 +349,7 @@ class SIP:
 
     def make_cancel_sip_packet(self, remote_id, remote_host, branch, tag, call_id, seq):
         # Assemble the request uri
-        uri = 'sip:' + remote_id + '@' + remote_host;
+        uri = 'sip:' + remote_id + '@' + remote_host
 
         # Assemble the header fields
         fields = collections.OrderedDict()
@@ -367,7 +367,7 @@ class SIP:
 
     def make_bye_sip_packet(self, remote_id, remote_host, branch, tag, remote_tag, call_id, seq):
         # Assemble the request uri
-        uri = 'sip:' + remote_id + '@' + remote_host;
+        uri = 'sip:' + remote_id + '@' + remote_host
 
         # Assemble the header fields
         fields = collections.OrderedDict()
@@ -430,7 +430,7 @@ class SIP:
                 if not 'WWW-Authenticate' in res.fields:
                     error('Did not find "WWW-Authenticate" field')
                     return
-                auth = str(res.fields['WWW-Authenticate'], 'ascii');
+                auth = str(res.fields['WWW-Authenticate'], 'ascii')
                 match = re.match(
                     r'^[Dd]igest\s+realm="([^"]*)"\s*,\s*nonce="([^"]*)"$',
                     auth)


### PR DESCRIPTION
Firstly, thank you so much for femtosip. It was exactly what I needed to complete a personal project.

### PJSIP compatibility

PJSIP on FreePBX/Asterisk sends extra keys in the WWW-Authenticate field. E.g.

```
Digest realm="asterisk",nonce="1234567890/aabbccddeeff00112233445566778899",opaque="a1b2c3d4e5f6",algorithm=md5,qop="auth"
```

The existing regex for parsing WWW-Authenticate doesn't match when extra keys are present and femtosip crashes. 

This is fixed in 4f54a14d2d825be05c0757e95d9d1181373fa916 by matching zero or more additional characters after the nonce value.

### Redundant semicolons

Some lines ended in semicolons. While this is technically valid in Python, it's discouraged.